### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# These owners will be requested for review when someone opens a pull request:
+*       @yftacherzog @Yuval-Vino


### PR DESCRIPTION
Code owners are defined in CODEOWNERS file with their GitHub username.
When a pull request is submitted that modifies files in the repository, GitHub automatically assigns code review requests to the appropriate code owners. This helps ensure that code changes are properly reviewed and approved by the appropriate people before they are merged into the repository.
Code owners are not automatically requested to review draft pull requests.

closes #61 