### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+### Desired Outcome
+
+*Please describe the desired outcome for this PR.  Said another way, what was
+the original request that resulted in these code changes?*
+
+### Implemented Changes
+
+*Describe how the desired outcome above has been achieved with this PR. In
+particular, consider:*
+
+- _What's changed? Why were these changes made?_
+- _How should the reviewer approach this PR_
+
+### Connected Issue/Story
+
+Resolves #[relevant issue(s), e.g. 47]
+
+### Dependencies
+
+This section inidicates whether this PR depends on any other PR's. 
+Might need to wait for other PR's to merged before. Add the PR ID.
+- [ ] This PR depends on other PR's
+  changes
+- [ ] This PR does not depend on other PR's 
+
+### Definition of Done
+*Feel free to copy this information from the connected issue.*
+
+#### Test coverage
+
+- [ ] This PR includes new unit and integration tests to go with the code
+  changes
+- [ ] The changes in this PR do not require tests
+
+#### Documentation
+
+- [ ] Docs (e.g. `README`s) were updated in this PR
+- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
+- [ ] This PR does not require updating any documentation


### PR DESCRIPTION
GitHub automatically looks for certain files in the .github directory of the repository, including pull request templates. If there is a file named PULL_REQUEST_TEMPLATE.md in the .github directory, it will be used as the default pull request template for your repository. When someone opens a new pull request, they will see the contents of this file as the default description.

closes #53 