### PR TITLE
Add login template

### DIFF
--- a/meet_balls_app/templates/base.html
+++ b/meet_balls_app/templates/base.html
@@ -18,7 +18,10 @@
     <nav class="navbar navbar-expand-md navbar bg-warning">
       <div class="container-fluid">
         <a class="navbar-brand" href="/">MeetBalls</a>
-        <button
+        {% if user.is_authenticated %}
+        <P class="navbar-nav ms-auto ">Hello {{user.username}}!</P>
+        {% endif %}
+          <button
           class="navbar-toggler"
           type="button"
           data-bs-toggle="collapse"
@@ -39,11 +42,11 @@
             </li>
             {% if user.is_authenticated %}
             <li class="nav-item">
-              <a class="nav-link" href="#">Logout</a>
+              <a class="nav-link" href="/logout">Logout</a>
             </li>
             {% else %}
             <li class="nav-item">
-              <a class="nav-link" href="#">Login</a>
+              <a class="nav-link" href="/login">Login</a>
             </li>
             {% endif %}
           </ul>

--- a/meet_balls_app/templates/meet_balls_app/login.html
+++ b/meet_balls_app/templates/meet_balls_app/login.html
@@ -1,0 +1,31 @@
+{% extends 'base.html'%}
+{%block content%}
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-6 col-lg-4">
+            <h2 class="text-center mb-4">Login</h2>
+            <form method="post">
+                {% csrf_token %}
+                <div class="mb-3">
+                    <label for="username" class="form-label">Username:</label>
+                    <input type="text" class="form-control" name="username" required>
+                </div>
+                <div class="mb-3">
+                    <label for="password" class="form-label">Password:</label>
+                    <input type="password" class="form-control" name="password" required>
+                </div>
+                <button type="submit" class="btn btn-primary">Login</button>
+            </form>
+            <p>Don't have an account? Register now.</p>
+            {% if messages %}
+            <ul class="messages">
+                {% for message in messages %}
+                <li{% if message.tags %} class="{{ message.tags }}" {% endif %}>{{ message }}</li>
+                    {% endfor %}
+            </ul>
+            
+            {% endif %}
+        </div>
+    </div>
+</div>
+{%endblock%}

--- a/meet_balls_app/tests.py
+++ b/meet_balls_app/tests.py
@@ -1,4 +1,5 @@
 import pytest
+from django.urls import reverse
 
 
 class TestUi:
@@ -22,3 +23,47 @@ class TestUi:
         response = client.get('/game-events/create/')
         assert response.status_code == 200
         assert b'<form' in response.content
+
+
+@pytest.mark.django_db
+class Testlogin:
+    def test_successful_login(self, client, player):
+        username = "daniel"
+        password = "password"
+
+        login_url = reverse('loginUser')
+        response = client.post(
+            login_url, {'username': username, 'password': password})
+
+        assert response.templates[0].name == 'meet_balls_app/home.html'
+        assert response.status_code == 200
+        assert response.context['user']['is_authenticated'] is True
+        assert response.context['user']['username'] == username
+
+    @pytest.mark.parametrize('username, password', [
+        ('wronguser', 'wrongpass'),
+        ('daniel', 'wrongpass'),
+        ('wronguser', 'password'),
+    ])
+    def test_unsuccessful_login(self, client, username, password):
+        login_url = reverse('loginUser')
+        response = client.post(
+            login_url, {'username': username, 'password': password})
+        assert response.status_code == 200
+        assert response.templates[0].name == 'meet_balls_app/login.html'
+        assert response.context['user']['is_authenticated'] is False
+        assert 'Invalid username or password.' in str(response.content)
+
+
+@pytest.mark.django_db
+class Testlogout:
+    def test_successful_logout(self, client, player):
+        username = "daniel"
+        password = "password"
+        login_url = reverse('loginUser')
+        client.post(login_url, {'username': username, 'password': password})
+        logout_url = reverse('logoutUser')
+        response = client.post(logout_url)
+        assert response.status_code == 200
+        assert response.templates[0].name == 'meet_balls_app/home.html'
+        assert response.context['user']['is_authenticated'] is False

--- a/meet_balls_app/views.py
+++ b/meet_balls_app/views.py
@@ -1,5 +1,29 @@
 from django.shortcuts import render
+from django.contrib.auth import authenticate, logout, login
+from django.contrib import messages
 
 
 def home(request):
     return render(request, 'meet_balls_app/home.html')
+
+
+def loginUser(request):
+    if request.method == 'POST':
+        username = request.POST.get('username')
+        password = request.POST.get('password')
+        user = authenticate(request, username=username, password=password)
+        if user is not None:
+            login(request, user)
+            return render(request, 'meet_balls_app/home.html',
+                          {'user': {'is_authenticated': True, 'username': username}})
+        else:
+            error_message = "Invalid username or password."
+            messages.error(request, error_message)
+            return render(request, 'meet_balls_app/login.html', {'user': {'is_authenticated': False, 'username': None}})
+    else:
+        return render(request, 'meet_balls_app/login.html', {'user': {'is_authenticated': False, 'username': None}})
+
+
+def logoutUser(request):
+    logout(request)
+    return render(request, 'meet_balls_app/home.html', {'user': {'is_authenticated': False}})

--- a/meetballs/urls.py
+++ b/meetballs/urls.py
@@ -24,4 +24,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('', app_views.home, name='home'),
     path('game-events/', include("game_event.urls")),
+    path('login/', app_views.loginUser, name='loginUser'),
+    path('logout/', app_views.logoutUser, name='logoutUser'),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/player/migrations/0002_static_players.py
+++ b/player/migrations/0002_static_players.py
@@ -1,0 +1,31 @@
+from django.db import migrations, transaction
+from player.models import BallGame
+import datetime
+import random
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('player', '0001_initial'),
+    ]
+
+    def generate_data(apps, schema_editor):
+
+        from player.models import Player
+        password = 'password123'
+        static_players = []
+        for i in range(5):
+            username = f'user{i + 1}'
+            random_birth_date = datetime.date(1950, 1, 1) + datetime.timedelta(days=random.randint(0, 20055))
+            random_favorite_ball_game = random.choice(BallGame.choices)[0]
+            static_players.append((username, random_birth_date, random_favorite_ball_game))
+
+        with transaction.atomic():
+            for username, birth_date, favorite_ball_game in static_players:
+                Player.create(username=username, password=password, birth_date=birth_date,
+                              favorite_ball_game=favorite_ball_game)
+
+    operations = [
+            migrations.RunPython(generate_data),
+        ]


### PR DESCRIPTION
### Desired Outcome

1. Users as players would have a template for login.
2. The template would have routing from the login page to the home page, and the other way around.

### Implemented Changes

1. Add login.html template file
2. Add login, and logout paths to the meetballs/urls.py file.
3. Add login, logout methods to render relevant pages in the meet_balls_app/views.py file.
4. Modify base.html file with the relvant new href's for the login/logout botton.

### Connected Issue/Story

Resolves #[74]

### Dependencies

- [x] This PR depends on other PR's
  changes
- [ ] This PR does not depend on other PR's 

### Definition of Done

1. Login page template should be added.
2. Relevant routing for the template should be added.
3. Small adjustments in the base.html should be done.
4. Relevant tests for the login mechanism should be added.

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation