### PR TITLE
Add button in game-events.html to create game-event form page

### DIFF
--- a/game_event/templates/game-events.html
+++ b/game_event/templates/game-events.html
@@ -39,6 +39,7 @@
 				<th>Ballgame</th>
 			</tr>
 		</thead>
+        <a href="/game-events/create" class="btn btn-primary mb-2">Create Game Event</a>
 		<tbody>
 			{% for event in game_events %}
 			<tr>


### PR DESCRIPTION
### Desired Outcome

game-events page should have a button that will send users to create event form
### Implemented Changes

Add a line with a button that has href to "game-events/create" in game-events template

### Connected Issue/Story

Resolves #78 

### Dependencies

- [x] This PR does not depend on other PR's 

### Definition of Done
game-events will display button for create game event

#### Test coverage

- [x] The changes in this PR do not require tests

#### Documentation

- [x] This PR does not require updating any documentation