### PR TITLE
Add court and court_ball_game to conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,28 @@
 from player.models import BallGame, Player
+from court.models import Court
+from court_ball_game.models import CourtBallGame
+from decimal import Decimal
 import pytest
 
 
 @pytest.fixture
 def player():
     player = Player.create(
-        username='daniel',
+        username='Player',
         password='password',
         birth_date='1990-01-01',
         favorite_ball_game=BallGame.Soccer)
     return player
+
+
+@pytest.fixture
+def court():
+    court = Court.objects.create(x=Decimal('11'), y=Decimal('22'),
+                                 city='TEST_CITY', neighborhood='TEST_NEIGHBORHOOD', max_players=30)
+    return court
+
+
+@pytest.fixture
+def court_ball_game(court):
+    court_ball_game = CourtBallGame.objects.create(court=court, ball_game=BallGame.Basketball)
+    return court_ball_game

--- a/court/tests.py
+++ b/court/tests.py
@@ -8,12 +8,6 @@ from django.core.exceptions import ValidationError
 @pytest.mark.django_db
 class TestCourtModel:
 
-    @pytest.fixture
-    def court(self):
-        court = Court.objects.create(x=Decimal('11'), y=Decimal('22'),
-                                     city='TEST_CITY', neighborhood='TEST_NEIGHBORHOOD', max_players=30)
-        return court
-
     def test_get_instance(self, court):
         court_in_db = Court.objects.get(pk=court.pk)
         assert court_in_db == court

--- a/court_ball_game/tests.py
+++ b/court_ball_game/tests.py
@@ -1,7 +1,5 @@
 from .models import CourtBallGame
-from court.models import Court
 from player.models import BallGame
-from decimal import Decimal
 from django.db.utils import IntegrityError
 from django.core.exceptions import ValidationError
 import pytest
@@ -10,59 +8,48 @@ import pytest
 @pytest.mark.django_db
 class TestCourtBallGameModel:
 
-    @pytest.fixture
-    def court_instance(self):
-        court = Court.objects.create(courtID=1, x=Decimal('11'), y=Decimal('22'),
-                                     city='TEST_CITY', neighborhood='TEST_NEIGHBORHOOD', max_players=30)
-        return court
-
-    @pytest.fixture
-    def court_ball_game_instance(self, court_instance):
-        court_ball_game = CourtBallGame.objects.create(court=court_instance, ball_game=BallGame.Basketball)
-        return court_ball_game
-
-    def test_unique_together(self, court_ball_game_instance):
+    def test_unique_together(self, court_ball_game):
         with pytest.raises(IntegrityError):
-            CourtBallGame.objects.create(court=court_ball_game_instance.court,
-                                         ball_game=court_ball_game_instance.ball_game)
+            CourtBallGame.objects.create(court=court_ball_game.court,
+                                         ball_game=court_ball_game.ball_game)
 
-    def test_create_court_ball_game(self, court_ball_game_instance):
-        assert isinstance(court_ball_game_instance, CourtBallGame)
+    def test_create_court_ball_game(self, court_ball_game):
+        assert isinstance(court_ball_game, CourtBallGame)
 
     def test_create_court_ball_game_invalid_court_id(self):
         with pytest.raises(IntegrityError):
             CourtBallGame.objects.create(court=None, ball_game=BallGame.Basketball)
 
-    def test_create_court_ball_game_invalid_ball_game(self, court_instance):
+    def test_create_court_ball_game_invalid_ball_game(self, court):
         with pytest.raises(ValidationError):
-            CourtBallGame.objects.create(court=court_instance, ball_game='Invalid-Ball-Game').full_clean()
+            CourtBallGame.objects.create(court=court, ball_game='Invalid-Ball-Game').full_clean()
 
-    def test_update_court_ball_game(self, court_ball_game_instance):
-        court_ball_game_instance.ball_game = BallGame.Volleyball
-        court_ball_game_instance.save()
-        updated_court_ball_game = CourtBallGame.objects.get(id=court_ball_game_instance.id)
+    def test_update_court_ball_game(self, court_ball_game):
+        court_ball_game.ball_game = BallGame.Volleyball
+        court_ball_game.save()
+        updated_court_ball_game = CourtBallGame.objects.get(id=court_ball_game.id)
         assert updated_court_ball_game.ball_game == BallGame.Volleyball
 
-    def test_delete_court_ball_game(self, court_ball_game_instance):
-        court_ball_game_instance.delete()
+    def test_delete_court_ball_game(self, court_ball_game):
+        court_ball_game.delete()
         with pytest.raises(CourtBallGame.DoesNotExist):
-            CourtBallGame.objects.get(id=court_ball_game_instance.id)
+            CourtBallGame.objects.get(id=court_ball_game.id)
 
-    def test_create_court_ball_game_with_blank_ball_game(self, court_instance):
+    def test_create_court_ball_game_with_blank_ball_game(self, court):
         with pytest.raises(ValidationError):
             CourtBallGame.objects.create(
-                court=court_instance,
+                court=court,
                 ball_game='').full_clean()
 
-    def test_create_court_ball_game_with_null_ball_game(self, court_instance):
+    def test_create_court_ball_game_with_null_ball_game(self, court):
         with pytest.raises(ValidationError):
             CourtBallGame.objects.create(
-                court=court_instance
+                court=court
             ).full_clean()
 
-    def test_is_ball_game_playable(self, court_instance, court_ball_game_instance):
-        assert CourtBallGame.is_ball_game_playable(court_instance, BallGame.Basketball)
+    def test_is_ball_game_playable(self, court, court_ball_game):
+        assert CourtBallGame.is_ball_game_playable(court, BallGame.Basketball)
 
-    def test_is_ball_game_playable_false(self, court_instance):
+    def test_is_ball_game_playable_false(self, court):
         expected = False
-        assert expected == CourtBallGame.is_ball_game_playable(court_instance, BallGame.Basketball)
+        assert expected == CourtBallGame.is_ball_game_playable(court, BallGame.Basketball)

--- a/game_event/test_game_event_views.py
+++ b/game_event/test_game_event_views.py
@@ -1,28 +1,22 @@
 import pytest
 from django.urls import reverse
-from .models import GameEvent, Court
-from decimal import Decimal
+from .models import GameEvent
 from .views import game_events
 from django.utils import timezone
 
 
 @pytest.mark.django_db
 class TestGameEventServerResponses:
-    @pytest.fixture
-    def saved_court(self):
-        court = Court.objects.create(x=Decimal('11'), y=Decimal('22'),
-                                     city='TEST_CITY', neighborhood='TEST_NEIGHBORHOOD', max_players=30)
-        return court
 
     @pytest.fixture
-    def saved_game_event(self, saved_court):
+    def saved_game_event(self, court):
         game_event = GameEvent.objects.create(
             id=1000,
             time=timezone.now() - timezone.timedelta(days=1),
             level_of_game=5,
             min_number_of_players=4,
             max_number_of_players=10,
-            court=saved_court,
+            court=court,
             ball_game='Basketball'
         )
         return game_event

--- a/game_event_player/tests.py
+++ b/game_event_player/tests.py
@@ -5,8 +5,6 @@ from django.core.exceptions import ValidationError
 from .models import GameEventPlayer
 from game_event.models import GameEvent
 from player.models import Player, BallGame
-from court.models import Court
-from decimal import Decimal
 from django.utils import timezone
 
 
@@ -74,24 +72,17 @@ def players(saved_player, saved_player2, saved_player3):
 
 
 @pytest.fixture
-def saved_court():
-    court = Court.objects.create(x=Decimal('11'), y=Decimal('22'),
-                                 city='TEST_CITY', neighborhood='TEST_NEIGHBORHOOD', max_players=30)
-    return court
-
-
-@pytest.fixture
-def saved_game_event(saved_court):
+def saved_game_event(court):
     game_event = GameEvent.objects.create(id=ID1, time=timezone.now(), level_of_game=3,
-                                          min_number_of_players=2, max_number_of_players=5, court=saved_court,
+                                          min_number_of_players=2, max_number_of_players=5, court=court,
                                           ball_game='Basketball')
     return game_event
 
 
 @pytest.fixture
-def saved_game_event2(saved_court):
+def saved_game_event2(court):
     game_event = GameEvent.objects.create(id=ID2, time=timezone.now(), level_of_game=3,
-                                          min_number_of_players=2, max_number_of_players=5, court=saved_court,
+                                          min_number_of_players=2, max_number_of_players=5, court=court,
                                           ball_game='Basketball')
     return game_event
 

--- a/meet_balls_app/tests.py
+++ b/meet_balls_app/tests.py
@@ -31,7 +31,7 @@ class TestUi:
 @pytest.mark.django_db
 class Testlogin:
     def test_successful_login(self, client, player):
-        username = "daniel"
+        username = "Player"
         password = "password"
 
         login_url = reverse('loginUser')
@@ -45,7 +45,7 @@ class Testlogin:
 
     @pytest.mark.parametrize('username, password', [
         ('wronguser', 'wrongpass'),
-        ('daniel', 'wrongpass'),
+        ('Player', 'wrongpass'),
         ('wronguser', 'password'),
     ])
     def test_unsuccessful_login(self, client, username, password):

--- a/message/tests.py
+++ b/message/tests.py
@@ -1,9 +1,7 @@
 from django.contrib.auth import get_user_model
 from player.models import Player, BallGame
 from game_event.models import GameEvent
-from court.models import Court
 from message.models import Message
-from decimal import Decimal
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 import pytest
@@ -36,16 +34,10 @@ class TestMessageModel:
         return player
 
     @pytest.fixture
-    def saved_court(self):
-        court = Court.objects.create(x=Decimal('11'), y=Decimal('22'),
-                                     city='TEST_CITY', neighborhood='TEST_NEIGHBORHOOD', max_players=30)
-        return court
-
-    @pytest.fixture
-    def saved_game_event(self, saved_court):
+    def saved_game_event(self, court):
         return GameEvent.objects.create(id=TEST_ID, time=TEST_TIME, level_of_game=TEST_LEVEL,
                                         min_number_of_players=TEST_MIN, max_number_of_players=TEST_MAX,
-                                        court=saved_court, ball_game=TEST_BALL_GAME)
+                                        court=court, ball_game=TEST_BALL_GAME)
 
     @pytest.fixture
     def saved_message(self, saved_player, saved_game_event):


### PR DESCRIPTION
### Desired Outcome

one fixture of court and court_ball_game, reducing the creation of those entities in test files.
Will make the code more readable.

### Implemented Changes

-  court and court_ball_game fixtures added to conftest.
-  Adjustments were made in the relevant test files for change to work: remove court and court_ball_game from the test files, changed the name from saved_ court => court, court_ball_game_instance / saved_court_ball_game => court_ball_game.
- Removed saved_player from game_event tests, player already in contest no need for the same fixture in that file.

### Connected Issue/Story

Resolves #80 

### Dependencies

- [x] This PR does not depend on other PR's 

### Definition of Done
one court and court_ all_game fixture, that all the other test files will use if needed

#### Test coverage

- [x] The changes in this PR do not require tests

#### Documentation

- [x] Most of the test files required adjustments.