### PR TITLE
Add current weather info to game event table

### DIFF
--- a/game_event/templates/game-events.html
+++ b/game_event/templates/game-events.html
@@ -36,6 +36,9 @@
 				<th>Minimum Players</th>
 				<th>Maximum Players</th>
 				<th>Court ID</th>
+                <th>City</th>
+                <th>Curr Temp</th>
+                <th>Curr Weather</th>
 				<th>Ballgame</th>
 			</tr>
 		</thead>
@@ -44,12 +47,20 @@
 		<tbody>
 			{% for event in game_events %}
 			<tr>
-				<td><a href="http://127.0.0.1:8000/game-events/{{ event.id }}/">{{ event.id }}</a></td>
+				<td><a href="/game-events/{{ event.id }}/">{{ event.id }}</a></td>
 				<td>{{ event.time }}</td>
 				<td>{{ event.level_of_game }}</td>
 				<td>{{ event.min_number_of_players }}</td>
 				<td>{{ event.max_number_of_players }}</td>
-				<td><a href="http://127.0.0.1:8000/courts/{{ event.court.courtID }}">{{ event.court.courtID }}</a></td>
+				<td><a href="/courts/{{ event.court.courtID }}">{{ event.court.courtID }}</a></td>
+                <td>{{ event.court.city }}</td>
+                {% if event.weather %}
+                    <td>  {{ event.weather.temp}} </td>
+                    <td>  <img src={{ event.weather.icon }}> </td>
+                {% else %}
+                    <td> N/A </td>
+                    <td> N/A </td>
+                {% endif %}
 				<td>{{ event.ball_game }}</td>
 			</tr>
 			{% endfor %}

--- a/game_event/test_game_event_views.py
+++ b/game_event/test_game_event_views.py
@@ -17,29 +17,35 @@ class TestGameEventServerResponses:
     def test_shown_min_player_filter(self, client, game_event):
         response = client.get(reverse(game_events), {'min_players': '2'})
         assert response.status_code == 200
-        assert game_event in response.context['game_events']
+        game_events_response = response.context['game_events']
+        assert any(game.id == game_event.id for game in game_events_response)
 
     def test_not_shown_min_player_filter(self, client, game_event):
         response = client.get(reverse(game_events), {'min_players': '10'})
         assert response.status_code == 200
-        assert game_event not in response.context['game_events']
+        game_events_response = response.context['game_events']
+        assert not any(game.id == game_event.id for game in game_events_response)
 
     def test_shown_max_player_filter(self, client, game_event):
         response = client.get(reverse(game_events), {'max_players': '15'})
         assert response.status_code == 200
-        assert game_event in response.context['game_events']
+        game_events_response = response.context['game_events']
+        assert any(game.id == game_event.id for game in game_events_response)
 
     def test_not_shown_max_player_filter(self, client, game_event):
         response = client.get(reverse(game_events), {'max_players': '2'})
         assert response.status_code == 200
-        assert game_event not in response.context['game_events']
+        game_events_response = response.context['game_events']
+        assert not any(game.id == game_event.id for game in game_events_response)
 
     def test_shown_max_level_filter(self, client, game_event):
         response = client.get(reverse(game_events), {'max_level': '10'})
         assert response.status_code == 200
-        assert game_event in response.context['game_events']
+        game_events_response = response.context['game_events']
+        assert any(game.id == game_event.id for game in game_events_response)
 
     def test_not_shown_max_level_filter(self, client, game_event):
         response = client.get(reverse(game_events), {'max_level': '2'})
         assert response.status_code == 200
-        assert game_event not in response.context['game_events']
+        game_events_response = response.context['game_events']
+        assert not any(game.id == game_event.id for game in game_events_response)


### PR DESCRIPTION
### Desired Outcome

Current temperature and weather icons will be added to the game event table for each game event.

### Implemented Changes

Modify game events template, view, and tests. Current weather details are shown in the game event table.

### Connected Issue/Story
Resolves #91

### Dependencies

This section inidicates whether this PR depends on any other PR's. 
Might need to wait for other PR's to merged before. Add the PR ID.
- [x] This PR depends on other PR's
  changes
- [ ] This PR does not depend on other PR's 

### Definition of Done

1.Add view that make http get request to openweather api at game_event/views.py 
2.Modify game-events.html template
3.Add tests for the weather view at game_event/tests.py


#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation


![image](https://github.com/redhat-beyond/MeetBalls/assets/95130756/16916a65-8475-4bdc-a57a-a7c1445f235d)
