### PR TITLE
Add game_event and game_event_player fixtures to conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -22,7 +22,7 @@ def player():
 
 @pytest.fixture
 def player_rating(player):
-    return PlayerRating.objects.create(ball_game="Basketball", player=player, rating=5)
+    return PlayerRating.objects.create(ball_game=BallGame.Baseball, player=player, rating=5)
 
 
 @pytest.fixture
@@ -50,16 +50,22 @@ def notification(player):
 
 
 @pytest.fixture
-def game_event(court, court_ball_game):
+def game_event(court):
     return GameEvent.objects.create(
-        id=20,
+        id=2,
         time=timezone.now(),
-        level_of_game=5,
-        min_number_of_players=3,
+        level_of_game=3,
+        min_number_of_players=2,
         max_number_of_players=5,
-        court=court, ball_game="Basketball")
+        court=court,
+        ball_game=BallGame.Baseball
+        )
 
 
 @pytest.fixture
 def game_event_player(game_event, player):
-    return GameEventPlayer.objects.create(game_event=game_event, player=player, ball_responsible=False)
+    return GameEventPlayer.objects.create(
+        game_event=game_event,
+        player=player,
+        ball_responsible=False
+        )

--- a/game_event/test_game_event_views.py
+++ b/game_event/test_game_event_views.py
@@ -1,25 +1,10 @@
 import pytest
 from django.urls import reverse
-from .models import GameEvent
 from .views import game_events
-from django.utils import timezone
 
 
 @pytest.mark.django_db
 class TestGameEventServerResponses:
-
-    @pytest.fixture
-    def saved_game_event(self, court):
-        game_event = GameEvent.objects.create(
-            id=1000,
-            time=timezone.now() - timezone.timedelta(days=1),
-            level_of_game=5,
-            min_number_of_players=4,
-            max_number_of_players=10,
-            court=court,
-            ball_game='Basketball'
-        )
-        return game_event
 
     def test_loading_site_no_filters(self, client):
         response = client.get('/game-events/')
@@ -29,32 +14,32 @@ class TestGameEventServerResponses:
         response = client.get('/game-eventsss/')
         assert response.status_code == 404
 
-    def test_shown_min_player_filter(self, client, saved_game_event):
+    def test_shown_min_player_filter(self, client, game_event):
         response = client.get(reverse(game_events), {'min_players': '2'})
         assert response.status_code == 200
-        assert saved_game_event in response.context['game_events']
+        assert game_event in response.context['game_events']
 
-    def test_not_shown_min_player_filter(self, client, saved_game_event):
+    def test_not_shown_min_player_filter(self, client, game_event):
         response = client.get(reverse(game_events), {'min_players': '10'})
         assert response.status_code == 200
-        assert saved_game_event not in response.context['game_events']
+        assert game_event not in response.context['game_events']
 
-    def test_shown_max_player_filter(self, client, saved_game_event):
+    def test_shown_max_player_filter(self, client, game_event):
         response = client.get(reverse(game_events), {'max_players': '15'})
         assert response.status_code == 200
-        assert saved_game_event in response.context['game_events']
+        assert game_event in response.context['game_events']
 
-    def test_not_shown_max_player_filter(self, client, saved_game_event):
+    def test_not_shown_max_player_filter(self, client, game_event):
         response = client.get(reverse(game_events), {'max_players': '2'})
         assert response.status_code == 200
-        assert saved_game_event not in response.context['game_events']
+        assert game_event not in response.context['game_events']
 
-    def test_shown_max_level_filter(self, client, saved_game_event):
+    def test_shown_max_level_filter(self, client, game_event):
         response = client.get(reverse(game_events), {'max_level': '10'})
         assert response.status_code == 200
-        assert saved_game_event in response.context['game_events']
+        assert game_event in response.context['game_events']
 
-    def test_not_shown_max_level_filter(self, client, saved_game_event):
+    def test_not_shown_max_level_filter(self, client, game_event):
         response = client.get(reverse(game_events), {'max_level': '2'})
         assert response.status_code == 200
-        assert saved_game_event not in response.context['game_events']
+        assert game_event not in response.context['game_events']

--- a/game_event/tests.py
+++ b/game_event/tests.py
@@ -1,11 +1,11 @@
-from .models import GameEvent
+from game_event.models import GameEvent
+from game_event_player.models import GameEventPlayer
 from django.core.exceptions import ValidationError
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 from player.models import BallGame
 from django.urls import reverse
 from .views import process_game_event_form
-from game_event_player.models import GameEventPlayer
 from datetime import timedelta
 import pytest
 from django.db import IntegrityError
@@ -18,37 +18,24 @@ TEST_MAX = 5
 TEST_BALL_GAME = 'Basketball'
 
 
-@pytest.fixture
-def saved_game_event(court):
-    return GameEvent.objects.create(id=TEST_ID, time=TEST_TIME, level_of_game=TEST_LEVEL,
-                                    min_number_of_players=TEST_MIN, max_number_of_players=TEST_MAX,
-                                    court=court, ball_game=TEST_BALL_GAME)
-
-
-@pytest.fixture
-def saved_game_event_player(saved_game_event, player):
-    return GameEventPlayer.objects.create(game_event=saved_game_event, player=player,
-                                          ball_responsible=False)
-
-
 @pytest.mark.django_db
 class TestGameEventModel:
 
-    def test_get_game_event(self, saved_game_event):
-        game_event = GameEvent.objects.get(pk=saved_game_event.pk)
-        assert game_event == saved_game_event
+    def test_get_game_event(self, game_event):
+        game_event = GameEvent.objects.get(pk=game_event.pk)
+        assert game_event == game_event
 
-    def test_update_game_event(self, saved_game_event):
-        game_event = saved_game_event
-        assert saved_game_event.ball_game != BallGame.Volleyball
+    def test_update_game_event(self, game_event):
+        game_event = game_event
+        assert game_event.ball_game != BallGame.Volleyball
         game_event.ball_game = BallGame.Volleyball
         game_event.save()
         updated_game_event = GameEvent.objects.get(pk=game_event.pk)
         assert updated_game_event.ball_game == BallGame.Volleyball
 
-    def test_delete_game_event(self, saved_game_event):
-        pk = saved_game_event.pk
-        saved_game_event.delete()
+    def test_delete_game_event(self, game_event):
+        pk = game_event.pk
+        game_event.delete()
         with pytest.raises(GameEvent.DoesNotExist):
             GameEvent.objects.get(pk=pk)
 
@@ -181,9 +168,9 @@ class TestGameEventModel:
 @pytest.mark.django_db
 class TestGameEventViews:
 
-    def test_success_loading_site_game_event(self, client, saved_game_event, player):
+    def test_success_loading_site_game_event(self, client, game_event, player):
         client.force_login(player.user)
-        game_event_id = saved_game_event.id
+        game_event_id = game_event.id
         url = reverse('game_event', args=[game_event_id])
         response = client.get(url)
         assert response.status_code == 200
@@ -194,9 +181,9 @@ class TestGameEventViews:
         assert response.status_code == 200
         assert b"Event Does not exist." in response.content
 
-    def test_success_loading_site_join_game_event(self, client, saved_game_event, player):
+    def test_success_loading_site_join_game_event(self, client, game_event, player):
         client.force_login(player.user)
-        game_event_id = saved_game_event.id
+        game_event_id = game_event.id
         url = reverse('join_event', args=[game_event_id])
         response = client.get(url)
         assert response.status_code == 200
@@ -207,9 +194,9 @@ class TestGameEventViews:
         assert response.status_code == 200
         assert b"Can not join, Event Does Not exist! " in response.content
 
-    def test_success_loading_site_remove_game_event(self, client, saved_game_event, saved_game_event_player):
-        client.force_login(saved_game_event_player.player.user)
-        game_event_id = saved_game_event.id
+    def test_success_loading_site_remove_game_event(self, client, game_event, game_event_player):
+        client.force_login(game_event_player.player.user)
+        game_event_id = game_event.id
         url = reverse('remove_from_event', args=[game_event_id])
         response = client.get(url)
         assert response.status_code == 200
@@ -220,46 +207,46 @@ class TestGameEventViews:
         assert response.status_code == 200
         assert b"Can not remove from event, Event Does not Exist! " in response.content
 
-    def test_fail_loading_remove_from_event_after_deleting_the_game_event(self, client, saved_game_event,
-                                                                          saved_game_event_player):
-        client.force_login(saved_game_event_player.player.user)
-        game_event_id = saved_game_event.id
+    def test_fail_loading_remove_from_event_after_deleting_the_game_event(self, client, game_event,
+                                                                          game_event_player):
+        client.force_login(game_event_player.player.user)
+        game_event_id = game_event.id
         url = reverse('remove_from_event', args=[game_event_id])
         response = client.get(url)
         assert response.status_code == 200
-        saved_game_event.delete()
+        game_event.delete()
         response = client.get(url)
         assert response.status_code == 200
         assert b"Can not remove from event, Event Does not Exist! " in response.content
 
-    def test_remove_player_from_event(self, client, saved_game_event, saved_game_event_player):
-        client.force_login(saved_game_event_player.player.user)
-        game_event_id = saved_game_event.id
+    def test_remove_player_from_event(self, client, game_event, game_event_player):
+        client.force_login(game_event_player.player.user)
+        game_event_id = game_event.id
         url = reverse('remove_from_event', args=[game_event_id])
         response = client.get(url)
         assert response.status_code == 200
         with pytest.raises(ObjectDoesNotExist):
-            GameEventPlayer.objects.get(game_event=saved_game_event, player=saved_game_event_player.player)
+            GameEventPlayer.objects.get(game_event=game_event, player=game_event_player.player)
 
-    def test_remove_player_that_is_not_in_event(self, client, saved_game_event, player):
+    def test_remove_player_that_is_not_in_event(self, client, game_event, player):
         client.force_login(player.user)
-        game_event_id = saved_game_event.id
+        game_event_id = game_event.id
         url = reverse('remove_from_event', args=[game_event_id])
         with pytest.raises(ObjectDoesNotExist):
             client.get(url)
 
-    def test_add_player_to_event(self, client, saved_game_event, player):
+    def test_add_player_to_event(self, client, game_event, player):
         client.force_login(player.user)
-        game_event_id = saved_game_event.id
+        game_event_id = game_event.id
         url = reverse('process_answer_game_event', args=[game_event_id])
         response = client.post(url, {'answer': 'yes'})
         assert response.status_code == 200
         assert response.context['in_event']
-        assert GameEventPlayer.objects.filter(game_event=saved_game_event, player=player).exists()
+        assert GameEventPlayer.objects.filter(game_event=game_event, player=player).exists()
 
-    def test_fail_add_player_to_event_already_in_it(self, client, saved_game_event, player):
+    def test_fail_add_player_to_event_already_in_it(self, client, game_event, player):
         client.force_login(player.user)
-        game_event_id = saved_game_event.id
+        game_event_id = game_event.id
         url = reverse('process_answer_game_event', args=[game_event_id])
         response = client.post(url, {'answer': 'yes'})
         assert response.status_code == 200

--- a/game_event_player/tests.py
+++ b/game_event_player/tests.py
@@ -37,16 +37,6 @@ def user3():
 
 
 @pytest.fixture
-def saved_player(user):
-    player = Player.objects.create(
-        user=user,
-        birth_date='1990-01-01',
-        favorite_ball_game=BallGame.Soccer
-    )
-    return player
-
-
-@pytest.fixture
 def saved_player2(user2):
     player = Player.objects.create(
         user=user2,
@@ -67,16 +57,8 @@ def saved_player3(user3):
 
 
 @pytest.fixture
-def players(saved_player, saved_player2, saved_player3):
-    return tuple([saved_player, saved_player2, saved_player3])
-
-
-@pytest.fixture
-def saved_game_event(court):
-    game_event = GameEvent.objects.create(id=ID1, time=timezone.now(), level_of_game=3,
-                                          min_number_of_players=2, max_number_of_players=5, court=court,
-                                          ball_game='Basketball')
-    return game_event
+def players(player, saved_player2, saved_player3):
+    return tuple([player, saved_player2, saved_player3])
 
 
 @pytest.fixture
@@ -87,63 +69,57 @@ def saved_game_event2(court):
     return game_event
 
 
-@pytest.fixture
-def saved_game_event_player(saved_game_event, saved_player):
-    return GameEventPlayer.objects.create(game_event=saved_game_event, player=saved_player,
-                                          ball_responsible=False)
-
-
 @pytest.mark.django_db
 class TestGameEventPlayerModel:
 
-    def test_game_event_player_creation(self, saved_game_event, saved_player):
-        game_event_player = GameEventPlayer.objects.create(game_event=saved_game_event, player=saved_player,)
+    def test_game_event_player_creation(self, game_event, player):
+        game_event_player = GameEventPlayer.objects.create(game_event=game_event, player=player,)
         game_event_player.full_clean()
-        assert game_event_player.game_event == saved_game_event
-        assert game_event_player.player == saved_player
+        assert game_event_player.game_event == game_event
+        assert game_event_player.player == player
         assert game_event_player.ball_responsible is False
 
-    def test_filter_players_by_event(self, saved_game_event, saved_game_event2, players):
-        GameEventPlayer.objects.create(game_event=saved_game_event, player=players[0], ball_responsible=False)
-        GameEventPlayer.objects.create(game_event=saved_game_event, player=players[1], ball_responsible=False)
-        GameEventPlayer.objects.create(game_event=saved_game_event, player=players[2], ball_responsible=False)
+    def test_filter_players_by_event(self, game_event, saved_game_event2, players):
+        GameEventPlayer.objects.create(game_event=game_event, player=players[0], ball_responsible=False)
+        GameEventPlayer.objects.create(game_event=game_event, player=players[1], ball_responsible=False)
+        GameEventPlayer.objects.create(game_event=game_event, player=players[2], ball_responsible=False)
         GameEventPlayer.objects.create(game_event=saved_game_event2, player=players[0], ball_responsible=False)
         GameEventPlayer.objects.create(game_event=saved_game_event2, player=players[1], ball_responsible=False)
         p1 = GameEventPlayer.objects.filter(player=players[0])
         events = sorted([entry.game_event.id for entry in p1])
         expected_events = sorted([ID1, ID2])
         assert expected_events == events
-        e1 = GameEventPlayer.objects.filter(game_event=saved_game_event)
+        e1 = GameEventPlayer.objects.filter(game_event=game_event)
         players = sorted([entry.player.user for entry in e1], key=str)
         expected_players = sorted(players, key=str)
         assert expected_players == players
 
-    def test_unique_together_constraint(self, saved_game_event, saved_player):
-        GameEventPlayer.objects.create(game_event=saved_game_event, player=saved_player, ball_responsible=False)
+    def test_unique_together_constraint(self, game_event, player):
+        GameEventPlayer.objects.create(game_event=game_event, player=player, ball_responsible=False)
         with pytest.raises(IntegrityError):
-            GameEventPlayer.objects.create(game_event=saved_game_event, player=saved_player,
+            GameEventPlayer.objects.create(game_event=game_event, player=player,
                                            ball_responsible=False)
 
-    def test_get_game_event_player(self, saved_game_event_player):
-        game_event_player = GameEventPlayer.objects.get(pk=saved_game_event_player.pk)
-        assert game_event_player == saved_game_event_player
+    def test_get_game_event_player(self, game_event_player):
+        game_event_player = GameEventPlayer.objects.get(pk=game_event_player.pk)
+        assert game_event_player == game_event_player
 
-    def test_create_game_event_player_with_empty_player(self, saved_game_event):
+    def test_create_game_event_player_with_empty_player(self, game_event):
         with pytest.raises(IntegrityError):
-            GameEventPlayer.objects.create(game_event=saved_game_event, player=Player.objects.create(),
+            GameEventPlayer.objects.create(game_event=game_event, player=Player.objects.create(),
                                            ball_responsible=False)
 
-    def test_create_game_event_player_with_empty_game_event(self, saved_player):
+    def test_create_game_event_player_with_empty_game_event(self, player):
         with pytest.raises(IntegrityError):
-            GameEventPlayer.objects.create(game_event=GameEvent.objects.create(), player=saved_player,
+            GameEventPlayer.objects.create(game_event=GameEvent.objects.create(), player=player,
                                            ball_responsible=False)
 
-    def test_create_game_event_player_with_blank_ball_responsible(self, saved_game_event, saved_player):
+    def test_create_game_event_player_with_blank_ball_responsible(self, game_event, player):
         with pytest.raises(ValidationError):
-            GameEventPlayer.objects.create(game_event=saved_game_event, player=saved_player,
+            GameEventPlayer.objects.create(game_event=game_event, player=player,
                                            ball_responsible='').full_clean()
 
-    def test_create_game_event_player_with_invalid_ball_responsible(self, saved_game_event, saved_player):
+    def test_create_game_event_player_with_invalid_ball_responsible(self, game_event, player):
         with pytest.raises(ValidationError):
-            GameEventPlayer.objects.create(game_event=saved_game_event, player=saved_player,
+            GameEventPlayer.objects.create(game_event=game_event, player=player,
                                            ball_responsible='invalid - should be boolean').full_clean()

--- a/message/tests.py
+++ b/message/tests.py
@@ -1,5 +1,4 @@
-from django.contrib.auth import get_user_model
-from player.models import Player, BallGame
+from player.models import Player
 from game_event.models import GameEvent
 from message.models import Message
 from django.core.exceptions import ValidationError
@@ -18,32 +17,10 @@ TEST_BALL_GAME = 'Basketball'
 class TestMessageModel:
 
     @pytest.fixture
-    def user(self):
-        return get_user_model().objects.create_user(
-            username='testuser',
-            password='testpass'
-        )
-
-    @pytest.fixture
-    def saved_player(self, user):
-        player = Player.objects.create(
-            user=user,
-            birth_date='1990-01-01',
-            favorite_ball_game=BallGame.Soccer
-        )
-        return player
-
-    @pytest.fixture
-    def saved_game_event(self, court):
-        return GameEvent.objects.create(id=TEST_ID, time=TEST_TIME, level_of_game=TEST_LEVEL,
-                                        min_number_of_players=TEST_MIN, max_number_of_players=TEST_MAX,
-                                        court=court, ball_game=TEST_BALL_GAME)
-
-    @pytest.fixture
-    def saved_message(self, saved_player, saved_game_event):
+    def saved_message(self, player, game_event):
         message = Message.objects.create(
-            user_id=saved_player,
-            game_event_id=saved_game_event,
+            user_id=player,
+            game_event_id=game_event,
             time_sent=TEST_TIME,
             text="test message"
         )
@@ -80,27 +57,27 @@ class TestMessageModel:
         with pytest.raises(Message.DoesNotExist):
             Message.objects.get(pk=saved_message.pk)
 
-    def test_create_message_with_valid_fields(self, saved_player, saved_game_event):
+    def test_create_message_with_valid_fields(self, player, game_event):
         Message.objects.create(
-            user_id=saved_player,
-            game_event_id=saved_game_event,
+            user_id=player,
+            game_event_id=game_event,
             time_sent=TEST_TIME,
             text="Idan and Ohad").full_clean()
 
-    def test_create_message_with_invalid_text_length(self, saved_player, saved_game_event):
+    def test_create_message_with_invalid_text_length(self, player, game_event):
         with pytest.raises(ValidationError):
             Message.objects.create(
-                user_id=saved_player,
-                game_event_id=saved_game_event,
+                user_id=player,
+                game_event_id=game_event,
                 time_sent=TEST_TIME,
                 text="I" * 260
             ).full_clean()
 
-    def test_create_message_with_empty_text(self, saved_player, saved_game_event):
+    def test_create_message_with_empty_text(self, player, game_event):
         with pytest.raises(ValidationError):
             Message.objects.create(
-                user_id=saved_player,
-                game_event_id=saved_game_event,
+                user_id=player,
+                game_event_id=game_event,
                 time_sent=TEST_TIME,
                 text=""
             ).full_clean()


### PR DESCRIPTION
###Desired Outcome

one fixture of game_event and game_event_player, reducing the creation of those entities in test files.
Will make the code more readable.

###Implemented Changes

game_event and game_event_player fixtures added to conftest.
Adjustments were made in the relevant test files for change to work: remove game_event and game_event_player from the test files, changed the name from saved_ game_event => game_event, saved_game_event_player => game_event_player.

###Connected Issue/Story

Resolves #82 #81 

###Dependencies

 This PR does not depend on other PR's
Definition of Done

one game_event and one game_event_player fixture, all the other test files will use those fixtures if needed.

Test coverage

 The changes in this PR do not require tests
Documentation

 Most of the test files required adjustments.