### PR TITLE
Add message fixture to conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from player_rating.models import PlayerRating
 from game_event.models import GameEvent
 from game_event_player.models import GameEventPlayer
+from message.models import Message
 import pytest
 
 
@@ -69,3 +70,14 @@ def game_event_player(game_event, player):
         player=player,
         ball_responsible=False
         )
+
+
+@pytest.fixture
+def message(player, game_event):
+    message = Message.objects.create(
+        user_id=player,
+        game_event_id=game_event,
+        time_sent=timezone.now(),
+        text="test message"
+    )
+    return message

--- a/message/tests.py
+++ b/message/tests.py
@@ -7,58 +7,42 @@ from django.utils import timezone
 from django.urls import reverse
 import pytest
 
-
-TEST_ID = 2
 TEST_TIME = timezone.now()
-TEST_LEVEL = 3
-TEST_MIN = 2
-TEST_MAX = 5
-TEST_BALL_GAME = 'Basketball'
 
 
 @pytest.mark.django_db
 class TestMessageModel:
 
-    @pytest.fixture
-    def saved_message(self, player, game_event):
-        message = Message.objects.create(
-            user_id=player,
-            game_event_id=game_event,
-            time_sent=TEST_TIME,
-            text="test message"
-        )
-        return message
+    def test_get_message(self, message):
+        message = Message.objects.get(pk=message.pk)
+        assert message == message
 
-    def test_get_message(self, saved_message):
-        message = Message.objects.get(pk=saved_message.pk)
-        assert message == saved_message
-
-    def test_update_message(self, saved_message):
+    def test_update_message(self, message):
         new_text = "test message?!"
-        message = saved_message
+        message = message
         assert message.text != new_text
         message.text = new_text
         message.save()
         updated_message = Message.objects.get(pk=message.pk)
         assert updated_message.text == new_text
 
-    def test_delete_message(self, saved_message):
-        message = saved_message
+    def test_delete_message(self, message):
+        message = message
         message.delete()
         with pytest.raises(Message.DoesNotExist):
-            Message.objects.get(pk=saved_message.pk)
+            Message.objects.get(pk=message.pk)
 
-    def test_delete_game_event_deletes_message(self, saved_message):
-        game_event = GameEvent.objects.get(id=saved_message.game_event_id.id)
+    def test_delete_game_event_deletes_message(self, message):
+        game_event = GameEvent.objects.get(id=message.game_event_id.id)
         game_event.delete()
         with pytest.raises(Message.DoesNotExist):
-            Message.objects.get(pk=saved_message.pk)
+            Message.objects.get(pk=message.pk)
 
-    def test_delete_user_deletes_message(self, saved_message):
-        player = Player.objects.get(user=saved_message.user_id)
+    def test_delete_user_deletes_message(self, message):
+        player = Player.objects.get(user=message.user_id)
         player.delete()
         with pytest.raises(Message.DoesNotExist):
-            Message.objects.get(pk=saved_message.pk)
+            Message.objects.get(pk=message.pk)
 
     def test_create_message_with_valid_fields(self, player, game_event):
         Message.objects.create(


### PR DESCRIPTION
 **### Desired Outcome**

one fixture of message in conftest and rename the message fixture from saved_message to message, 
will make the code more readable.

**### Implemented Changes**

1. message fixture added to conftest.
2. removing the saved_message fixture from message test
3. rename the saved_message fixture to be message.

 **### Connected Issue/Story**

Resolves #115 #106 

**### Dependencies**

- [ ] This PR does not depend on other PR's 


 **### Test coverage**

- [ ] The changes in this PR do not require tests

**### Documentation**

- [ ] This PR does not require updating any documentation